### PR TITLE
add json_halt to remove return JSON.dump(...)

### DIFF
--- a/app/app.rb
+++ b/app/app.rb
@@ -33,18 +33,15 @@ class Mosscow < Sinatra::Base
   end
 
   get '/404' do
-    response.status = 404
-    haml :not_found
+    halt 404, haml(:not_found)
   end
 
   get '/500' do
-    response.status = 500
-    haml :internal_server_error
+    halt 500, haml(:internal_server_error)
   end
 
   get '/400' do
-    response.status = 400
-    haml :bad_request
+    halt 400, haml(:bad_request)
   end
 
   get '/' do

--- a/app/app.rb
+++ b/app/app.rb
@@ -26,6 +26,12 @@ class Mosscow < Sinatra::Base
     content_type 'text/html'
   end
 
+  helpers do
+    def json_halt status, object
+      halt status, {'Content-Type' => 'text/plain'}, JSON.dump(object)
+    end
+  end
+
   get '/404' do
     response.status = 404
     haml :not_found
@@ -73,31 +79,26 @@ class Mosscow < Sinatra::Base
       params = JSON.parse(request.body.read)
     rescue => e
       p e.backtrace
-      response.status = 400
-      return JSON.dump({ message: 'set valid JSON for request raw body.'})
+      json_halt 400, { message: 'set valid JSON for request raw body.'}
     end
 
     %w{is_done order task_title}.each do |key_string|
       unless params.has_key?(key_string)
-        response.status = 400
         p params
-        return JSON.dump({ message:'set appropriate parameters.'})
+        json_halt 400, { message:'set appropriate parameters.'}
       end
     end
 
     unless params['is_done'] == true or params['is_done'] == false
-      response.status = 400
-      return JSON.dump({ message:'parameter "done" must be false or true.'})
+      json_halt 400, { message:'parameter "done" must be false or true.'}
     end
 
     unless params['order'].is_a?(Integer)
-      response.status = 400
-      return JSON.dump({ message:'parameter "order" must be an integer.'})
+      json_halt 400, { message:'parameter "order" must be an integer.'}
     end
 
     unless params['task_title'].is_a?(String)
-      response.status = 400
-      return JSON.dump({ message:'parameter "title" must be a string.'})
+      json_halt 400, { message:'parameter "title" must be a string.'}
     end
 
     todo = Todo.create(params)

--- a/app/app.rb
+++ b/app/app.rb
@@ -28,7 +28,7 @@ class Mosscow < Sinatra::Base
 
   helpers do
     def json_halt status, object
-      halt status, {'Content-Type' => 'text/plain'}, JSON.dump(object)
+      halt status, {'Content-Type' => 'application/json'}, JSON.dump(object)
     end
   end
 


### PR DESCRIPTION
sinatra でエラーコードを返すふつうのやり方に`halt`があります。

``` ruby
get '/error' do
    halt 401,  "見ないでください＞＜"
end
```

この halt をラップして、エラーメッセージをJSONで返す json_halt を つくりました。
json_halt を使って return JSON.dump(...) を撲滅します。
