### PR TITLE
[Check Please] error handling middleware

### DIFF
--- a/app/app.rb
+++ b/app/app.rb
@@ -15,6 +15,7 @@ class Mosscow < Sinatra::Base
   set :static, true
   set :public_folder, 'public'
   set :views, File.dirname(__FILE__) + '/views'
+  set :show_exceptions, false # temporary
   set :database_file, 'config/database.yml'
 
   configure :development do
@@ -42,6 +43,10 @@ class Mosscow < Sinatra::Base
 
   get '/400' do
     halt 400, haml(:bad_request)
+  end
+
+  get '/error' do
+    fail
   end
 
   get '/' do

--- a/app/app.rb
+++ b/app/app.rb
@@ -15,7 +15,8 @@ class Mosscow < Sinatra::Base
   set :static, true
   set :public_folder, 'public'
   set :views, File.dirname(__FILE__) + '/views'
-  set :show_exceptions, false # temporary
+  set :raise_errors, true
+  set :show_exceptions, false # delete here when you want to see a backtrace
   set :database_file, 'config/database.yml'
 
   configure :development do

--- a/app/app.rb
+++ b/app/app.rb
@@ -16,7 +16,7 @@ class Mosscow < Sinatra::Base
   set :public_folder, 'public'
   set :views, File.dirname(__FILE__) + '/views'
   set :raise_errors, true
-  set :show_exceptions, false # delete here when you want to see a backtrace
+  set :show_exceptions, true # set false here when you do NOT want to see a backtrace
   set :database_file, 'config/database.yml'
 
   configure :development do

--- a/app/middleware/errors_handler.rb
+++ b/app/middleware/errors_handler.rb
@@ -1,0 +1,23 @@
+require 'haml'
+
+class ErrorsHandler
+  def initialize(app)
+    @app = app
+  end
+
+  def call(env)
+    r = @app.call(env)
+    if r[0] == 500
+      response = Rack::Response.new do |res|
+        res.status = 500
+        res['Content-Type'] = 'application/json'
+        res.write '{"message":"unexpected error"}'
+      end
+
+      response.finish
+    else
+      r
+    end
+  # rescue ここのrescue無意味 :(
+  end
+end

--- a/app/middleware/errors_handler.rb
+++ b/app/middleware/errors_handler.rb
@@ -1,23 +1,17 @@
-require 'haml'
-
 class ErrorsHandler
   def initialize(app)
     @app = app
   end
 
   def call(env)
-    r = @app.call(env)
-    if r[0] == 500
-      response = Rack::Response.new do |res|
-        res.status = 500
-        res['Content-Type'] = 'application/json'
-        res.write '{"message":"unexpected error"}'
-      end
-
-      response.finish
-    else
-      r
+    @app.call(env)
+  rescue
+    response = Rack::Response.new do |res|
+      res.status = 500
+      res['Content-Type'] = 'application/json'
+      res.write '{"message":"unexpected error"}'
     end
-  # rescue ここのrescue無意味 :(
+
+    response.finish
   end
 end

--- a/config.ru
+++ b/config.ru
@@ -1,5 +1,7 @@
 require_relative 'app/app'
 require_relative 'app/middleware/camel_snake_exchanger'
+require_relative 'app/middleware/errors_handler'
 
+use ErrorsHandler
 use CamelSnakeExchanger
 run Mosscow

--- a/spec/app_spec.rb
+++ b/spec/app_spec.rb
@@ -59,7 +59,8 @@ describe 'app.rb' do
       ['{"moge":fuge}', 'set valid JSON for request raw body.'],
       ['{}',            'set appropriate parameters.'         ],
       ['{"is_done":"hoge", "order":1, "task_title":"hoge"}',    'parameter "done" must be false or true.'],
-      ['{"is_done":false, "order":"str", "task_title":"hoge"}', 'parameter "order" must be an integer.'  ]
+      ['{"is_done":false, "order":"str", "task_title":"hoge"}', 'parameter "order" must be an integer.'  ],
+      ['{"is_done":false, "order":1, "task_title":1.2}',        'parameter "title" must be a string.'    ]
     ].each do |params, message|
       it_should_behave_like 'invalid case', params, message
     end
@@ -74,9 +75,16 @@ describe 'app.rb' do
       end
     end
 
-    it_should_behave_like 'errors', 400
-    it_should_behave_like 'errors', 404
-    it_should_behave_like 'errors', 500
+    [400, 404, 500].each do |status|
+      it_should_behave_like 'errors', status
+    end
+  end
+
+  context 'GET /error' do
+    it 'returns 500' do
+      get '/error'
+      last_response.status.should eq 500
+    end
   end
 
 end

--- a/spec/middleware/errors_handler_spec.rb
+++ b/spec/middleware/errors_handler_spec.rb
@@ -1,0 +1,27 @@
+require_relative '../spec_helper'
+
+describe ErrorsHandler do
+  include Rack::Test::Methods
+
+  class MockedApp < Sinatra::Base
+    get '/error' do
+      fail
+    end
+  end
+
+  def app
+    @app ||= ErrorsHandler.new(MockedApp)
+  end
+
+  describe 'call' do
+    let(:expected){ '{"message":"unexpected error"}' }
+
+    it 'returns an error message and status 500' do
+      get '/error'
+
+      last_response.status.should eq 500
+      last_response.body.should eq expected
+    end
+  end
+
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,6 +7,7 @@ Coveralls.wear!
 # load code after this line
 require File.join(File.dirname(__FILE__), '..', 'app', 'app.rb')
 require File.join(File.dirname(__FILE__), '..', 'app', 'middleware', 'camel_snake_exchanger.rb')
+require File.join(File.dirname(__FILE__), '..', 'app', 'middleware', 'errors_handler.rb')
 
 RSpec.configure do |config|
   ENV['RACK_ENV'] ||= 'test'


### PR DESCRIPTION
#33 の 500用のエラーハンドラーを追加しました。Rack middlewareからhamlを呼び出すのが[面倒そうだった](http://blog.crowdint.com/2010/11/17/rack-basics-a-rack-introduction.html)ので、とりあえず、jsonで返してます。

もしかしたら、`get /500`とかいらないかも。
