### PR TITLE
get rid of noise from rspec logs

### DIFF
--- a/app/app.rb
+++ b/app/app.rb
@@ -77,7 +77,7 @@ class Mosscow < Sinatra::Base
     begin
       params = JSON.parse(request.body.read)
     rescue => e
-      p e.backtrace
+      p e.backtrace unless ENV['RACK_ENV'] == 'test'
       json_halt 400,  message: 'set valid JSON for request raw body.'
     end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,4 +10,7 @@ require File.join(File.dirname(__FILE__), '..', 'app', 'middleware', 'camel_snak
 
 RSpec.configure do |config|
   ENV['RACK_ENV'] ||= 'test'
+
+  # let RSpec be quiet while tests are running
+  ActiveRecord::Base.logger = nil
 end


### PR DESCRIPTION
rspecにノイズが沢山入ってるので、黙らせました。
- backtraceを環境が`test`の時に出力しない
- ActiveRecordのログも出力しない => `spec_helper.rb`で設定。
